### PR TITLE
added glorycoin easter egg

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -67,9 +67,16 @@ bot.onText(
   }
 );
 
-bot.onText(/brabo/,async (msg) => {
+bot.onText(/\/brabo/,async (msg) => {
   const chatId = msg.chat.id;
   bot.sendMessage(chatId,'Carai esse bot do Kazushi é brabo mermo ein')
+})
+
+bot.onText(/\/glory/,async (msg) => {
+  const chatId = msg.chat.id;
+  bot.sendMessage(chatId,
+    `Último preço: R$150.00\nPreço mais alto: R$150.00\nPreço mais baixo: R$150.00\nA variação em 24h foi de 00%`
+    )
 })
 
 module.exports = bot;


### PR DESCRIPTION
Why do we need that change?

- We need to keep in mind always te cotation of the glorycoin
- Always useful to know that 1 glorycoin equals to 150 brazilian Reais.
- It's a good easter egg that brings joy to our people in the hard times of Brazil.

Also, it corrects a regex typo on brabo command.